### PR TITLE
GitHub Actions: Deprecating set-output commands

### DIFF
--- a/.github/workflows/compare-packages.yml
+++ b/.github/workflows/compare-packages.yml
@@ -41,7 +41,7 @@ jobs:
           do
             comment+=$line
           done < $RUNNER_TEMP/report.md
-          echo "::set-output name=comment::$comment"
+          echo "comment=$comment" >> $GITHUB_OUTPUT
       - name: Comment on pull request
         if: steps.output.outputs.comment
         uses: unsplash/comment-on-pr@v1.3.0

--- a/.github/workflows/compare-packages.yml
+++ b/.github/workflows/compare-packages.yml
@@ -36,18 +36,21 @@ jobs:
         if: hashFiles('${{ env.RUNNER_TEMP }}/report.md') != ''
         id: output
         run: |
-          comment='<!-- ypkmtr unique comment -->'
+          report='<!-- ypkmtr unique comment -->'
           while read line
           do
-            comment+=$line
+            report+=$line
           done < $RUNNER_TEMP/report.md
-          echo "comment=$comment" >> $GITHUB_OUTPUT
+          echo "REPORT=$report" >> $GITHUB_OUTPUT
       - name: Comment on pull request
-        if: steps.output.outputs.comment
+        if: steps.output.outputs.REPORT
         uses: unsplash/comment-on-pr@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: ${{ steps.output.outputs.comment }}
+          msg: ${{ steps.output.outputs.REPORT }}
           check_for_duplicate_msg: false
           delete_prev_regex_msg: "<!-- ypkmtr unique comment -->"
+      - name: Action summary
+        if: steps.output.outputs.REPORT
+        run: echo "${{ steps.output.outputs.REPORT }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Updating usage of `set-output` since it can be exploited by unwanted actors. See link below

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/